### PR TITLE
fix: openrouter langchain example

### DIFF
--- a/examples/langchain/index.ts
+++ b/examples/langchain/index.ts
@@ -18,14 +18,12 @@ const chat = new ChatOpenAI(
     maxTokens: 300,
     streaming: true,
     openAIApiKey: OPENROUTER_API_KEY,
-  },
-  {
-    basePath: `${OPENROUTER_BASE_URL}/api/v1`,
-    baseOptions: {
-      headers: {
+    configuration: {
+      baseURL: "https://openrouter.ai/api/v1",
+      defaultHeaders: {
         "HTTP-Referer": "https://localhost:3000/",
         "X-Title": "Langchain.js Testing",
-      },
+      }
     },
   }
 )


### PR DESCRIPTION
Current version of the `ChatOpenAI` doesn't accept 2nd configuration argument. There is a `configuration` property in the 1st argument instead.