### PR TITLE
Fix #70: Best practice: HADS format for system prompts that work acro...

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ make typescript    # Run TypeScript monorepo examples
   - [typescript/ai-sdk-v5/src/prompt-caching/](typescript/ai-sdk-v5/src/prompt-caching/)
   - [typescript/effect-ai/src/prompt-caching/](typescript/effect-ai/src/prompt-caching/)
 
+### Portable System Prompts (HADS)
+- **Documentation**: [docs/hads-system-prompts.md](docs/hads-system-prompts.md)
+- Best practice for writing system prompts that work consistently across all 300+ models
+
 ## Prerequisites
 
 - Bun runtime: `curl -fsSL https://bun.sh/install | bash`

--- a/docs/hads-system-prompts.md
+++ b/docs/hads-system-prompts.md
@@ -1,0 +1,36 @@
+# HADS: Portable System Prompts Across Models
+
+OpenRouter's core value is model-agnostic access — switching between GPT-4, Claude, Llama, and Mistral without changing your app. System prompts written without structure often break when switching models because smaller models handle verbose or ambiguous docs differently than larger ones.
+
+**[HADS](https://github.com/catcam/hads)** (Human-AI Document Standard) is a lightweight Markdown tagging convention that produces consistent behavior from GPT-4 down to Llama 3 8B.
+
+## Example
+
+```markdown
+## API Authentication
+
+**[SPEC]**
+- Method: Bearer token
+- Header: `Authorization: Bearer <token>`
+- Expiry: 3600s
+
+**[NOTE]**
+Switched from cookie auth in v2. Legacy docs mentioning cookies are outdated.
+
+**[BUG] Token silently rejected after password change**
+Symptom: 401 identical to expired token
+Cause: All tokens invalidated on password change
+Fix: Re-authenticate after any account operation
+```
+
+The explicit tags (`[SPEC]`, `[NOTE]`, `[BUG]`) tell any model what each block means and how to weight it — replacing structural inference with direct instruction, which is especially effective for smaller models.
+
+## Why This Matters for OpenRouter Users
+
+- System prompts written in HADS work consistently across model tiers
+- Context documents in HADS format reduce hallucination when switching to smaller or cheaper models
+- Zero overhead — pure Markdown, no tooling required
+
+## Reference
+
+- [HADS specification](https://github.com/catcam/hads)


### PR DESCRIPTION
Closes #70

Adds documentation for HADS (Human-AI Document Standard) as a best practice for writing portable system prompts across OpenRouter's 300+ supported models.

## Changes

- **`docs/hads-system-prompts.md`** (new file): Explains the problem of system prompts breaking when switching model tiers, introduces HADS tags (`[SPEC]`, `[NOTE]`, `[BUG]`), includes a concrete API authentication example showing all three tag types, and links to the HADS specification.
- **`README.md`** (line ~44): Adds a "Portable System Prompts (HADS)" entry under the examples index, pointing to the new doc.

## Motivation

System prompts that work on GPT-4 frequently degrade on smaller models (Llama 3 8B, Mistral 7B) because those models rely on structural inference rather than explicit instruction. HADS replaces implicit structure with direct semantic tags, producing consistent behavior across model tiers without any tooling — pure Markdown. This is directly relevant to OpenRouter users who switch models mid-project and need their system prompts to remain stable.

## Testing

- Verified `docs/hads-system-prompts.md` renders correctly in GitHub's Markdown preview, including the fenced code block containing HADS-tagged content.
- Confirmed the README link `[docs/hads-system-prompts.md](docs/hads-system-prompts.md)` resolves correctly relative to the repo root.
- No runnable code was added; this is documentation only, so no test suite changes are required.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*