### PR TITLE
feat: add bounded AgentsKit tool-calling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ make typescript    # Run TypeScript monorepo examples
 │   ├── fetch/         - Raw fetch API examples
 │   ├── ai-sdk-v5/     - Vercel AI SDK v5 examples
 │   ├── effect-ai/     - Effect-TS examples
+│   ├── agentskit/     - Bounded tool-calling agent with replaceable models
 │   └── openrouter-sdk/ - OpenRouter SDK examples (TODO)
 ├── docs/              - Feature documentation
 └── Makefile           - Unified command interface
@@ -79,6 +80,7 @@ bash curl/prompt-caching.sh
 cd typescript/fetch && bun examples
 cd typescript/ai-sdk-v5 && bun examples
 cd typescript/effect-ai && bun examples
+cd typescript/agentskit && bun examples
 ```
 
 ## Benefits

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -8,6 +8,7 @@ A Bun monorepo containing OpenRouter examples across different TypeScript ecosys
 - **fetch/** - Raw fetch API examples
 - **ai-sdk-v5/** - Vercel AI SDK v5 examples (using ai v4.x package)
 - **effect-ai/** - Effect-TS AI examples
+- **agentskit/** - Bounded tool-calling agent with model-independent orchestration
 - **openrouter-sdk/** - OpenRouter TypeScript SDK examples (TODO)
 
 ## Prerequisites
@@ -41,6 +42,7 @@ bun examples
 cd fetch && bun examples
 cd ai-sdk-v5 && bun examples
 cd effect-ai && bun examples
+cd agentskit && bun examples
 ```
 
 ## Workspace Benefits

--- a/typescript/agentskit/README.md
+++ b/typescript/agentskit/README.md
@@ -1,0 +1,62 @@
+# AgentsKit bounded tool-calling agent
+
+This example uses OpenRouter as the model gateway and AgentsKit as the agent control layer. The model can change without rewriting the tool definitions, step ceiling, runtime, or application code.
+
+The agent investigates a synthetic checkout incident with two local tools:
+
+- `get_service_health`
+- `list_recent_deployments`
+
+It preserves tool-call IDs, returns structured results to the model, stops after at most four model steps, and prints an inspectable execution summary.
+
+## Run
+
+From `typescript/`:
+
+```bash
+bun install
+export OPENROUTER_API_KEY='your-key-here'
+bun --filter '@openrouter-examples/agentskit' examples
+```
+
+The default model is OpenRouter's free router:
+
+```bash
+export OPENROUTER_MODEL='openrouter/free'
+```
+
+To switch providers or models, change only `OPENROUTER_MODEL`:
+
+```bash
+export OPENROUTER_MODEL='openai/gpt-oss-20b:free'
+bun --filter '@openrouter-examples/agentskit' examples
+```
+
+You can pass a different investigation request after `--`:
+
+```bash
+bun --filter '@openrouter-examples/agentskit' examples -- 'Check the catalog service.'
+```
+
+## Validate without credentials
+
+```bash
+bun --filter '@openrouter-examples/agentskit' typecheck
+bun --filter '@openrouter-examples/agentskit' test
+```
+
+The tests use a scripted adapter and a mocked OpenRouter stream. They make no network requests and verify the step ceiling, structured tool results, selected model, and tool-call identity.
+
+## Control boundary
+
+`src/agent.ts` is the boundary between model access and application behavior:
+
+```ts
+const runtime = createRuntime({
+  adapter: openrouter({ apiKey, model }),
+  tools: incidentTools,
+  maxSteps: 4,
+});
+```
+
+OpenRouter owns model routing. AgentsKit owns the tool loop and execution contract. The synthetic tool bodies can be replaced with real metrics or deployment clients without changing the model gateway.

--- a/typescript/agentskit/package.json
+++ b/typescript/agentskit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openrouter-examples/agentskit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "examples": "bun run run-examples.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agentskit/adapters": "0.14.2",
+    "@agentskit/core": "1.12.7",
+    "@agentskit/runtime": "0.10.14"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.2",
+    "bun-types": "1.3.2"
+  }
+}

--- a/typescript/agentskit/run-examples.ts
+++ b/typescript/agentskit/run-examples.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env bun
+
+await import('./src/index.js');

--- a/typescript/agentskit/src/agent.ts
+++ b/typescript/agentskit/src/agent.ts
@@ -1,0 +1,27 @@
+import { openrouter } from '@agentskit/adapters';
+import type { AdapterFactory } from '@agentskit/core';
+import { createRuntime } from '@agentskit/runtime';
+import { incidentTools } from './tools.js';
+
+export const DEFAULT_MODEL = 'openrouter/free';
+export const MAX_STEPS = 4;
+
+export const SYSTEM_PROMPT = `You are an incident-triage assistant working from synthetic data.
+Use tools before making claims about service health or deployments.
+Correlate timestamps, distinguish evidence from inference, and recommend one safe next action.
+Do not invent systems, logs, metrics, or deployment details that the tools did not return.
+Finish with: evidence, likely cause, confidence, and next action.`;
+
+export function createIncidentRuntime(adapter: AdapterFactory) {
+  return createRuntime({
+    adapter,
+    tools: incidentTools,
+    systemPrompt: SYSTEM_PROMPT,
+    maxSteps: MAX_STEPS,
+    temperature: 0.1,
+  });
+}
+
+export function createOpenRouterIncidentRuntime(apiKey: string, model = DEFAULT_MODEL) {
+  return createIncidentRuntime(openrouter({ apiKey, model }));
+}

--- a/typescript/agentskit/src/incident-data.ts
+++ b/typescript/agentskit/src/incident-data.ts
@@ -1,0 +1,45 @@
+export const services = {
+  checkout: {
+    status: 'degraded',
+    errorRatePercent: 8.7,
+    p95LatencyMs: 1840,
+    startedAt: '2026-08-04T14:07:00Z',
+  },
+  catalog: {
+    status: 'healthy',
+    errorRatePercent: 0.2,
+    p95LatencyMs: 190,
+    startedAt: null,
+  },
+} as const;
+
+export const deployments = {
+  checkout: [
+    {
+      id: 'deploy-8472',
+      version: '2026.08.04-2',
+      deployedAt: '2026-08-04T14:02:00Z',
+      change: 'Enabled the new payment-provider retry policy',
+    },
+    {
+      id: 'deploy-8468',
+      version: '2026.08.04-1',
+      deployedAt: '2026-08-04T11:30:00Z',
+      change: 'Updated checkout page copy',
+    },
+  ],
+  catalog: [
+    {
+      id: 'deploy-8460',
+      version: '2026.08.03-3',
+      deployedAt: '2026-08-03T19:10:00Z',
+      change: 'Refreshed search index mappings',
+    },
+  ],
+} as const;
+
+export type ServiceName = keyof typeof services;
+
+export function isServiceName(value: string): value is ServiceName {
+  return value in services;
+}

--- a/typescript/agentskit/src/index.ts
+++ b/typescript/agentskit/src/index.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_MODEL, createOpenRouterIncidentRuntime } from './agent.js';
+
+const apiKey = process.env.OPENROUTER_API_KEY;
+
+if (!apiKey) {
+  throw new Error('OPENROUTER_API_KEY is required. Export it before running this example.');
+}
+
+const model = process.env.OPENROUTER_MODEL ?? DEFAULT_MODEL;
+const task =
+  process.argv.slice(2).join(' ') ||
+  [
+    'Checkout errors rose at 14:07 UTC.',
+    'Investigate the checkout service, identify the likely cause,',
+    'state your confidence, and recommend the safest next action.',
+  ].join(' ');
+
+const result = await createOpenRouterIncidentRuntime(apiKey, model).run(task);
+
+console.log(result.content);
+console.log('\nRun summary');
+console.log(
+  JSON.stringify(
+    {
+      model,
+      steps: result.steps,
+      toolCalls: result.toolCalls.map(({ id, name, status }) => ({ id, name, status })),
+      durationMs: result.durationMs,
+    },
+    null,
+    2,
+  ),
+);

--- a/typescript/agentskit/src/tools.ts
+++ b/typescript/agentskit/src/tools.ts
@@ -1,0 +1,58 @@
+import { type ToolDefinition, defineTool } from '@agentskit/core';
+import { deployments, isServiceName, services } from './incident-data.js';
+
+function requireService(value: string) {
+  if (!isServiceName(value)) {
+    throw new Error(
+      `Unknown service "${value}". Available services: ${Object.keys(services).join(', ')}`,
+    );
+  }
+  return value;
+}
+
+export const getServiceHealth = defineTool({
+  name: 'get_service_health',
+  description: 'Return current health signals for one service in the synthetic environment.',
+  schema: {
+    type: 'object',
+    properties: {
+      service: {
+        type: 'string',
+        enum: ['checkout', 'catalog'],
+        description: 'Service to inspect.',
+      },
+    },
+    required: ['service'],
+    additionalProperties: false,
+  } as const,
+  execute({ service }) {
+    const name = requireService(service);
+    return JSON.stringify({ service: name, ...services[name] });
+  },
+});
+
+export const listRecentDeployments = defineTool({
+  name: 'list_recent_deployments',
+  description: 'List recent deployments for one service in newest-first order.',
+  schema: {
+    type: 'object',
+    properties: {
+      service: {
+        type: 'string',
+        enum: ['checkout', 'catalog'],
+        description: 'Service whose deployment history should be inspected.',
+      },
+    },
+    required: ['service'],
+    additionalProperties: false,
+  } as const,
+  execute({ service }) {
+    const name = requireService(service);
+    return JSON.stringify({ service: name, deployments: deployments[name] });
+  },
+});
+
+export const incidentTools = [
+  getServiceHealth,
+  listRecentDeployments,
+] as unknown as ToolDefinition[];

--- a/typescript/agentskit/test/agent.test.ts
+++ b/typescript/agentskit/test/agent.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { AdapterFactory, AdapterRequest, StreamChunk } from '@agentskit/core';
+import { MAX_STEPS, createIncidentRuntime, createOpenRouterIncidentRuntime } from '../src/agent.js';
+import { getServiceHealth, listRecentDeployments } from '../src/tools.js';
+
+const originalFetch = globalThis.fetch;
+
+function scriptedAdapter(requests: AdapterRequest[]): AdapterFactory {
+  let call = 0;
+
+  return {
+    createSource(request) {
+      requests.push(request);
+      const current = call++;
+
+      return {
+        abort() {},
+        async *stream(): AsyncIterableIterator<StreamChunk> {
+          if (current === 0) {
+            yield {
+              type: 'tool_call',
+              toolCall: {
+                id: 'call-health-1',
+                name: 'get_service_health',
+                args: JSON.stringify({ service: 'checkout' }),
+              },
+            };
+          } else if (current === 1) {
+            yield {
+              type: 'tool_call',
+              toolCall: {
+                id: 'call-deployments-1',
+                name: 'list_recent_deployments',
+                args: JSON.stringify({ service: 'checkout' }),
+              },
+            };
+          } else {
+            yield {
+              type: 'text',
+              content: 'Evidence points to deploy-8472; confidence is high. Roll it back.',
+            };
+          }
+          yield { type: 'done' };
+        },
+      };
+    },
+  };
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('incident tools', () => {
+  it('returns structured synthetic health and deployment data', async () => {
+    const context = {
+      messages: [],
+      call: { id: 'test', name: 'test', args: {}, status: 'running' as const },
+    };
+
+    const health = JSON.parse(
+      String(await getServiceHealth.execute?.({ service: 'checkout' }, context)),
+    );
+    const recent = JSON.parse(
+      String(await listRecentDeployments.execute?.({ service: 'checkout' }, context)),
+    );
+
+    expect(health).toMatchObject({
+      service: 'checkout',
+      status: 'degraded',
+      errorRatePercent: 8.7,
+    });
+    expect(recent.deployments[0]).toMatchObject({ id: 'deploy-8472', version: '2026.08.04-2' });
+  });
+});
+
+describe('bounded runtime', () => {
+  it('preserves tool-call IDs and feeds results into the next step', async () => {
+    const requests: AdapterRequest[] = [];
+    const result = await createIncidentRuntime(scriptedAdapter(requests)).run(
+      'Investigate checkout errors.',
+    );
+
+    expect(result.steps).toBe(3);
+    expect(result.steps).toBeLessThanOrEqual(MAX_STEPS);
+    expect(result.toolCalls.map(({ id, name, status }) => ({ id, name, status }))).toEqual([
+      { id: 'call-health-1', name: 'get_service_health', status: 'complete' },
+      { id: 'call-deployments-1', name: 'list_recent_deployments', status: 'complete' },
+    ]);
+    expect(
+      requests[1].messages.some((message) =>
+        message.toolCalls?.some((toolCall) => toolCall.id === 'call-health-1'),
+      ),
+    ).toBe(true);
+    expect(
+      requests[1].messages.some(
+        (message) => message.role === 'tool' && message.toolCallId === 'call-health-1',
+      ),
+    ).toBe(true);
+    expect(result.content).toContain('deploy-8472');
+  });
+});
+
+describe('OpenRouter wire format', () => {
+  it('keeps the selected model and originating tool-call ID', async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const urls: string[] = [];
+    const responses = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call-health-1',
+                  function: { name: 'get_service_health', arguments: '{"service":"checkout"}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      { choices: [{ delta: { content: 'The checkout service is degraded.' } }] },
+    ];
+
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      urls.push(String(_input));
+      bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      const response = responses.shift();
+      return new Response(`data: ${JSON.stringify(response)}\n\ndata: [DONE]\n\n`, {
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }) as typeof fetch;
+
+    const model = 'openai/gpt-oss-20b:free';
+    await createOpenRouterIncidentRuntime('test-key', model).run('Check checkout.');
+
+    expect(urls[0]).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(bodies[0].model).toBe(model);
+    const secondMessages = bodies[1].messages as Array<Record<string, unknown>>;
+    expect(secondMessages).toContainEqual(
+      expect.objectContaining({
+        role: 'tool',
+        tool_call_id: 'call-health-1',
+      }),
+    );
+  });
+});

--- a/typescript/agentskit/tsconfig.json
+++ b/typescript/agentskit/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -13,7 +13,8 @@
     "shared",
     "fetch",
     "ai-sdk-v5",
-    "effect-ai"
+    "effect-ai",
+    "agentskit"
   ],
   "devDependencies": {
     "@types/bun": "1.3.2",


### PR DESCRIPTION
### What changed

This adds a self-contained AgentsKit workspace to the TypeScript examples. It uses OpenRouter as the model gateway and a bounded AgentsKit runtime to investigate a synthetic checkout incident with two local tools.

The example preserves tool-call identity, limits execution to four model steps, returns structured tool results, and prints an inspectable run summary. `OPENROUTER_MODEL` selects the model without changing the tools, orchestration, or application contract.

### Why

Calling a model is only one part of an agent. The surrounding loop also needs predictable stopping behavior, tool-result correlation, and enough execution data to understand what happened.

This example keeps that control boundary small and provider-independent while still using OpenRouter's unified model gateway. The synthetic tools can later be replaced with metrics or deployment clients without rewriting the model integration.

### Validation

- `bun --filter '@openrouter-examples/agentskit' typecheck`
- `bun --filter '@openrouter-examples/agentskit' test` — 3 deterministic tests, 11 assertions
- `bunx biome check agentskit`
- `bun audit --audit-level=high`
- `git diff --check`
- One live run with `openai/gpt-oss-20b:free`: 3/4 steps, both local tools completed, tool-call IDs remained correlated, and all required answer sections were present

The automated tests are credential-free and make no external requests. No key, raw provider payload or account data is included in the contribution.